### PR TITLE
[chore] reduce publish pkg size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-docs
-coverage
-test

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
     "version": "3.5.0",
     "description": "The node manage service api for cloudbase.",
     "main": "lib/index.js",
+    "files": [
+        "lib/",
+        "types/",
+        "CHANGELOG*"
+    ],
     "scripts": {
         "build": "rimraf lib types && npx tsc",
         "test": "jest --runInBand --detectOpenHandles --coverage --testTimeout=50000",


### PR DESCRIPTION
Eliminate unnecessary `ts` files to reduce the size of the distribution
before：
![2](https://user-images.githubusercontent.com/63141491/107840221-edd78a00-6deb-11eb-9e29-81794507c065.png)

after optmizing: 
![1](https://user-images.githubusercontent.com/63141491/107840214-e1533180-6deb-11eb-8260-7f32988e1923.png)
